### PR TITLE
[#14]: use new jql search endpoint

### DIFF
--- a/cypress/e2e/01-options.cy.ts
+++ b/cypress/e2e/01-options.cy.ts
@@ -385,7 +385,7 @@ describe('Options view & initial setup', () => {
     it('should setup and select issues for cloud', () => {
         cy.contains('h6', 'Authentification').should('be.visible')
         cy.fakeTimers(Date.now())
-        cy.intercept('https://jira.atlassian.com/rest/api/2/myself', {
+        cy.intercept('https://jira.atlassian.com/rest/api/3/myself', {
             displayName: 'Testuser',
             emailAddress: 'test@test.com',
             accountId: 'test1'
@@ -514,7 +514,7 @@ describe('Options view & initial setup', () => {
                 }
             ]
         })
-        cy.intercept('https://jira.atlassian.com/rest/api/2/search?jql=issuekey+in+*', (req) => {
+        cy.intercept('https://jira.atlassian.com/rest/api/3/search/jql?jql=issuekey+in+*', (req) => {
             const filteredIssues = issues.filter((issue) => req.url.includes(issue.key))
             const res = {
                 ...issueBody,
@@ -599,7 +599,7 @@ describe('Options view & initial setup', () => {
 
         cy.contains('div', 'Custom JQL Query').should('be.visible').find('textarea').type('test123', { delay: 100 })
 
-        cy.intercept('https://jira.atlassian.com/rest/api/2/search?*', []).as('search')
+        cy.intercept('https://jira.atlassian.com/rest/api/3/search/jql?*', []).as('search')
 
         cy.contains('div', 'Custom JQL Query').contains('a', 'Test Query').click()
         cy.wait('@search').its('request.url').should('contain', 'jql=test123')
@@ -637,7 +637,7 @@ describe('Options view & initial setup', () => {
             displayName: 'Testuser',
             key: 'test1'
         }).as('myselfData')
-        cy.intercept('https://jira.atlassian.com/rest/api/2/myself', {
+        cy.intercept('https://jira.atlassian.com/rest/api/3/myself', {
             displayName: 'Testuser',
             emailAddress: 'test@test.com',
             accountId: 'test1-cloud'
@@ -708,7 +708,7 @@ describe('Options view & initial setup', () => {
             displayName: 'Testuser',
             key: 'test1-datacenter'
         }).as('myselfData')
-        cy.intercept('https://jira.atlassian.com/rest/api/2/myself', {
+        cy.intercept('https://jira.atlassian.com/rest/api/3/myself', {
             displayName: 'Testuser',
             emailAddress: 'test@test.com',
             accountId: 'test1'

--- a/cypress/e2e/03-b-worklogs-cloud.cy.ts
+++ b/cypress/e2e/03-b-worklogs-cloud.cy.ts
@@ -99,7 +99,7 @@ describe('Tracking View - Worklog Entries - Cloud Api', () => {
                 }
             ]
         })
-        cy.intercept('https://jira.atlassian.org/rest/api/2/search?jql=issuekey+in+*', (req) => {
+        cy.intercept('https://jira.atlassian.org/rest/api/3/search/jql?jql=issuekey+in+*', (req) => {
             const filteredIssues = issues.filter((issue) => req.url.includes(issue.key))
             const res = {
                 ...issueBody,

--- a/cypress/support/defaults.ts
+++ b/cypress/support/defaults.ts
@@ -71,7 +71,7 @@ Cypress.Commands.add('networkMocksCloud', () => {
         req.reply(404)
     })
 
-    cy.intercept('GET', 'https://*.atlassian.org/rest/api/2/myself', {
+    cy.intercept('GET', 'https://*.atlassian.org/rest/api/3/myself', {
         displayName: 'Testuser',
         emailAddress: 'test@test.com',
         accountId: 'test1'
@@ -99,7 +99,7 @@ Cypress.Commands.add('networkMocksCloud', () => {
         })
     }).as('issuePicker')
 
-    cy.intercept('GET', 'https://*.atlassian.org/rest/api/2/search*', (req) => {
+    cy.intercept('GET', 'https://*.atlassian.org/rest/api/3/search/jql*', (req) => {
         const search = String(req.query.jql)
         const matches = Object.keys(issueIdKeyMap)
             .filter((key) => search.includes(key))

--- a/src/utils/api/cloud-api.ts
+++ b/src/utils/api/cloud-api.ts
@@ -52,10 +52,10 @@ const TEMPO = 'TEMPO'
 export const PATHS: Record<URLS, PathDefinition> = {
     [URLS.ISSUE]: { url: '/api/3/issue', type: JIRA },
     [URLS.QUICKSEARCH]: { url: '/api/3/issue/picker', type: JIRA },
-    [URLS.SEARCH]: { url: '/api/2/search', type: JIRA },
+    [URLS.SEARCH]: { url: '/api/3/search/jql', type: JIRA },
     [URLS.WORKLOGS]: { url: (accountId) => `/4/worklogs/user/${accountId}`, type: TEMPO },
     [URLS.CREATE_WORKLOG]: { url: '/4/worklogs', type: TEMPO },
-    [URLS.SELF]: { url: '/api/2/myself', type: JIRA }
+    [URLS.SELF]: { url: '/api/3/myself', type: JIRA }
 }
 
 const headers = (options: Options, url: URLS) => {
@@ -175,6 +175,7 @@ export async function fetchIssues(options, jql, limit?: number): Promise<Issue[]
     await checkPermissions(options)
     const query = new URLSearchParams()
     query.append('jql', jql)
+    query.append('fields', 'key,summary')
     if (limit) {
         query.append('maxResults', String(limit))
     }


### PR DESCRIPTION
This fixes #14. I was not able to check if the tests still run, since on my machine I get

```
> jira-log-time@3.8.0 test:server
> node ./test-server/index.js

node:internal/tls/secure-context:70
    context.setCert(cert);
            ^

Error: error:0A00018F:SSL routines::ee key too small
    at node:internal/tls/secure-context:70:13
    at Array.forEach (<anonymous>)
    at setCerts (node:internal/tls/secure-context:68:3)
    at configSecureContext (node:internal/tls/secure-context:191:5)
    at Object.createSecureContext (node:_tls_common:114:3)
    at Server.setSecureContext (node:_tls_wrap:1488:27)
    at Server (node:_tls_wrap:1352:8)
    at new Server (node:https:80:3)
    at Object.createServer (node:https:135:10)
    at Object.<anonymous> (/home/schulte/projects/Tempo-Tracker/test-server/index.js:113:27) {
  library: 'SSL routines',
  reason: 'ee key too small',
  code: 'ERR_SSL_EE_KEY_TOO_SMALL'
}

Node.js v20.19.4
```