### PR TITLE
fix: update Chrome Web Store URL to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Chrome Extension](https://chrome.google.com/webstore/detail/tempo-tracker/gcicdbcmacjeaepmfkibdbhickbdiafj)
+[Chrome Extension](https://chromewebstore.google.com/detail/tempo-tracker/gcicdbcmacjeaepmfkibdbhickbdiafj)
 [Edge Extension](https://microsoftedge.microsoft.com/addons/detail/tempotracker/bagmlbondklkiomfpeicbgmnbibadbck)
 [Firefox Extension](https://addons.mozilla.org/en-US/firefox/addon/tempo-tracker/)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jira-log-time",
     "version": "3.12.0",
-    "description": "Code repo for [Jira Log Time](https://chrome.google.com/webstore/detail/jira-log-time/peboekgeiffcaddndeonkmkledekeegl) chrome plugin.",
+    "description": "Code repo for [Jira Log Time](https://chromewebstore.google.com/detail/jira-log-time/peboekgeiffcaddndeonkmkledekeegl) chrome plugin.",
     "main": "jira-api.js",
     "scripts": {
         "start": "node build/esbuild.js",


### PR DESCRIPTION
Updates deprecated chrome.google.com/webstore URLs to new chromewebstore.google.com format.